### PR TITLE
Faster First Echo Request Processing

### DIFF
--- a/echo/components/database/client.py
+++ b/echo/components/database/client.py
@@ -31,7 +31,12 @@ def _configure_session() -> Session:
 
 
 class DatabaseClient:
-    def __init__(self, model: Type[SQLModel], db_url: str):
+    def __init__(self, model: Type[SQLModel] = None, db_url: str = None):
+        if model is None:
+            raise ValueError("model must be provided")
+        if db_url is None:
+            raise ValueError("db_url must be provided")
+
         self.model = model
         self.db_url = db_url + "/general/"
         self.session = _configure_session()

--- a/echo/components/loadbalancing/loadbalancer.py
+++ b/echo/components/loadbalancing/loadbalancer.py
@@ -68,11 +68,15 @@ class LoadBalancer(LightningFlow):
 
         return (work.status.timestamp + self.max_idle_seconds_per_work) < time.time()
 
-    def _ensure_min_replicas(self):
+    def ensure_min_replicas(self):
         """Checks for idle Works and stops them to save on cloud costs."""
         with self._work_pool_rw_lock:
             # Check for idle Works and stop them to save on cloud costs
             for work_name, work in self._work_pool.copy().items():
+                # FIXME(alecmerdler)
+                if len(self._work_pool.items()) <= self.min_replicas:
+                    return
+
                 if self._is_idle(work):
                     logger.info(f"Found idle Work ({work.name}), stopping it")
                     self._remove_work(work_name)


### PR DESCRIPTION
### Description

Adds logic to make a dummy 'recognizer.run()' call on app startup. In the cloud, this means a Work machine will be spun up and ready before the first actual 'create_echo' request comes in, and will not be blocked by spinning up a new machine.

In the future, hopefully the Lightning Framework will support a 'LightningWork.start()' method or something similar so we can remove this hack.

Resolves #12 