### PR TITLE
Fix Recorded Audio Playback on iOS

### DIFF
--- a/echo/media/mime.py
+++ b/echo/media/mime.py
@@ -1,0 +1,8 @@
+import magic
+
+# iOS does not support the <audio> tag for WebM files
+UNSUPPORTED_MEDIA_TYPES = ["video/webm"]
+
+
+def get_mimetype(filepath):
+    return magic.Magic(mime=True).from_file(filepath)

--- a/echo/ui/src/components/RecordEcho.tsx
+++ b/echo/ui/src/components/RecordEcho.tsx
@@ -64,6 +64,9 @@ export default function RecordEcho({
   } = useReactMediaRecorder({
     video: false,
     audio: true,
+    mediaRecorderOptions: {
+      mimeType: SupportedMediaType.audioWAV,
+    },
     onStop: (blobUrl, blob) => {
       setSourceBlob(blob);
       setSourceBlobURL(blobUrl);
@@ -152,7 +155,6 @@ export default function RecordEcho({
     (e: ChangeEvent<HTMLInputElement>) => {
       if (e.target.files && e.target.files.length > 0) {
         setSourceType(EchoSourceType.file);
-        // FIXME(alecmerdler): More accurate media type detection...
         setSourceMediaType(e.target.files[0].type as SupportedMediaType);
         setSourceBlob(e.target.files[0]);
         setSourceBlobURL(URL.createObjectURL(e.target.files[0]));

--- a/echo/ui/src/routes/dashboard/components/AudioPreview.tsx
+++ b/echo/ui/src/routes/dashboard/components/AudioPreview.tsx
@@ -22,9 +22,20 @@ export default function AudioPreview({ sourceFileURL, onCurrentTimeChange }: Pro
     }
   }, [onCurrentTimeChange]);
 
+  useEffect(() => {
+    if (audioPlayer.current) {
+      audioPlayer.current.addEventListener("error", () => {
+        if (audioPlayer.current) {
+          // FIXME(alecmerdler): Debugging
+          alert(`Error ${audioPlayer.current.error?.code}; details: ${audioPlayer.current.error?.message}`);
+        }
+      });
+    }
+  });
+
   return (
     <Stack height={"100%"} width={"100%"} padding={2}>
-      <audio style={{ width: "100%" }} ref={audioPlayer} src={sourceFileURL} controls />
+      <audio style={{ width: "100%" }} src={sourceFileURL} ref={audioPlayer} controls />
     </Stack>
   );
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ fastapi
 humps
 pytube
 sentry-sdk
+python-magic
 git+https://github.com/openai/whisper.git


### PR DESCRIPTION
### Description

Adds 'python-magic' library to correctly identify the mimetype
of the file in the download handler. Audio recorded in the
browser is 'video/webm' which is not supported in iOS, so
we convert it to 'audio/mp3' in the recognizer and persist
that file to the Drive instead.

This fixes a regression introduced when we were incorrectly
using the 'mimetypes' module, which only guesses based on
extension.