### PR TITLE
Display All Subtitles in Preview

### DIFF
--- a/echo/ui/src/components/RecordEcho.tsx
+++ b/echo/ui/src/components/RecordEcho.tsx
@@ -64,9 +64,6 @@ export default function RecordEcho({
   } = useReactMediaRecorder({
     video: false,
     audio: true,
-    mediaRecorderOptions: {
-      mimeType: SupportedMediaType.audioWAV,
-    },
     onStop: (blobUrl, blob) => {
       setSourceBlob(blob);
       setSourceBlobURL(blobUrl);

--- a/echo/ui/src/routes/dashboard/components/AudioPreview.tsx
+++ b/echo/ui/src/routes/dashboard/components/AudioPreview.tsx
@@ -4,11 +4,18 @@ import { Stack } from "@mui/material";
 
 type Props = {
   sourceFileURL: string;
+  playFrom: number;
   onCurrentTimeChange: (currentTime: number) => void;
 };
 
-export default function AudioPreview({ sourceFileURL, onCurrentTimeChange }: Props) {
+export default function AudioPreview({ sourceFileURL, playFrom, onCurrentTimeChange }: Props) {
   const audioPlayer = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    if (audioPlayer.current) {
+      audioPlayer.current.currentTime = playFrom;
+    }
+  }, [playFrom]);
 
   useEffect(() => {
     if (audioPlayer.current) {
@@ -21,17 +28,6 @@ export default function AudioPreview({ sourceFileURL, onCurrentTimeChange }: Pro
       return () => clearInterval(interval);
     }
   }, [onCurrentTimeChange]);
-
-  useEffect(() => {
-    if (audioPlayer.current) {
-      audioPlayer.current.addEventListener("error", () => {
-        if (audioPlayer.current) {
-          // FIXME(alecmerdler): Debugging
-          alert(`Error ${audioPlayer.current.error?.code}; details: ${audioPlayer.current.error?.message}`);
-        }
-      });
-    }
-  });
 
   return (
     <Stack height={"100%"} width={"100%"} padding={2}>

--- a/echo/ui/src/routes/dashboard/components/EchoDetail.tsx
+++ b/echo/ui/src/routes/dashboard/components/EchoDetail.tsx
@@ -27,6 +27,7 @@ export default function EchoDetail({ echoID, goBack }: Props) {
 
   const { data: echo, isLoading } = useGetEcho(echoID, true);
 
+  const [playMediaFrom, setPlayMediaFrom] = useState(0);
   const [currentSegment, setCurrentSegment] = useState(0);
 
   useEffect(() => {
@@ -74,13 +75,13 @@ export default function EchoDetail({ echoID, goBack }: Props) {
   const sourceFileURL = `${fileserverURL}/download/${echo.echo.id}`;
 
   const sourcePreview = isVideo(echo.echo.mediaType as SupportedMediaType) ? (
-    <VideoPreview sourceFileURL={sourceFileURL} onCurrentTimeChange={onCurrentTimeChange} />
+    <VideoPreview sourceFileURL={sourceFileURL} playFrom={playMediaFrom} onCurrentTimeChange={onCurrentTimeChange} />
   ) : (
-    <AudioPreview sourceFileURL={sourceFileURL} onCurrentTimeChange={onCurrentTimeChange} />
+    <AudioPreview sourceFileURL={sourceFileURL} playFrom={playMediaFrom} onCurrentTimeChange={onCurrentTimeChange} />
   );
 
   return (
-    <Stack direction={"column"}>
+    <Stack direction={"column"} height={"100%"}>
       <Stack padding={2}>
         <Breadcrumbs aria-label="breadcrumb">
           <Link color={"primary"} sx={{ ":hover": { cursor: "pointer" } }} onClick={() => goBack()}>
@@ -92,7 +93,7 @@ export default function EchoDetail({ echoID, goBack }: Props) {
       <Stack direction={"row"} justifyContent={"center"}>
         {sourcePreview}
       </Stack>
-      <Stack padding={2}>
+      <Stack padding={2} flexGrow={1}>
         <Stack direction={"row"} justifyContent={"space-between"} marginBottom={2}>
           <Typography variant={"h6"}>Captions</Typography>
           <Stack direction={"row"} spacing={2}>
@@ -116,9 +117,11 @@ export default function EchoDetail({ echoID, goBack }: Props) {
             />
           </Stack>
         </Stack>
-        {echo?.segments && echo.segments.length > 0 && currentSegment >= 0 && (
-          <Subtitles segments={echo.segments} currentSegment={currentSegment} />
-        )}
+        <Stack flexGrow={1} sx={{ overflowY: "scroll" }} maxHeight={"35vh"}>
+          {echo?.segments && echo.segments.length > 0 && currentSegment >= 0 && (
+            <Subtitles segments={echo.segments} currentSegment={currentSegment} onSelectTimestamp={setPlayMediaFrom} />
+          )}
+        </Stack>
       </Stack>
     </Stack>
   );

--- a/echo/ui/src/routes/dashboard/components/Subtitles.tsx
+++ b/echo/ui/src/routes/dashboard/components/Subtitles.tsx
@@ -1,46 +1,48 @@
+import { useEffect } from "react";
+
 import { Stack, Typography } from "@mui/material";
 
 import { Segment } from "types/echo";
 import { secondsToTime } from "utils/time";
 
+const subtitleIDFor = (segment: number) => `echo-subtitle-${segment}`;
+
 type Props = {
   segments: Segment[];
   currentSegment: number;
+  onSelectTimestamp: (timestamp: number) => void;
 };
 
-export default function Subtitles({ segments, currentSegment }: Props) {
+export default function Subtitles({ segments, currentSegment, onSelectTimestamp }: Props) {
   const formatStartTime = (startTime: number) => secondsToTime(Math.floor(startTime));
+
+  useEffect(() => {
+    const element = document.getElementById(subtitleIDFor(currentSegment));
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [currentSegment]);
 
   return (
     <Stack direction={"column"} spacing={1}>
-      {currentSegment > 1 && (
-        <Stack direction={"row"} spacing={4}>
-          <Typography variant={"body2"} color={"default"}>
-            {formatStartTime(segments[currentSegment - 2].start)}
+      {segments.map((segment, index) => (
+        <Stack
+          id={subtitleIDFor(index)}
+          key={segment.id}
+          direction={"row"}
+          spacing={4}
+          sx={{
+            cursor: "pointer",
+          }}
+          onClick={() => onSelectTimestamp(segment.start)}>
+          <Typography variant={"body2"} color={index === currentSegment ? "primary" : "default"}>
+            {formatStartTime(segment.start)}
           </Typography>
-          <Typography variant={"body2"} color={"default"}>
-            {segments[currentSegment - 2].text}
-          </Typography>
-        </Stack>
-      )}
-      {currentSegment > 0 && (
-        <Stack direction={"row"} spacing={4}>
-          <Typography variant={"body2"} color={"default"}>
-            {formatStartTime(segments[currentSegment - 1].start)}
-          </Typography>
-          <Typography variant={"body2"} color={"default"}>
-            {segments[currentSegment - 1].text}
+          <Typography variant={"body2"} color={index === currentSegment ? "primary" : "default"}>
+            {segment.text}
           </Typography>
         </Stack>
-      )}
-      <Stack direction={"row"} spacing={4}>
-        <Typography variant={"body2"} color={"primary"}>
-          {formatStartTime(segments[currentSegment].start)}
-        </Typography>
-        <Typography variant={"body2"} color={"primary"}>
-          {segments[currentSegment].text}
-        </Typography>
-      </Stack>
+      ))}
     </Stack>
   );
 }

--- a/echo/ui/src/routes/dashboard/components/VideoPreview.tsx
+++ b/echo/ui/src/routes/dashboard/components/VideoPreview.tsx
@@ -4,11 +4,18 @@ import { Stack } from "@mui/material";
 
 type Props = {
   sourceFileURL: string;
+  playFrom: number;
   onCurrentTimeChange: (currentTime: number) => void;
 };
 
-export default function VideoPreview({ sourceFileURL, onCurrentTimeChange }: Props) {
+export default function VideoPreview({ sourceFileURL, playFrom, onCurrentTimeChange }: Props) {
   const videoPlayer = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (videoPlayer.current) {
+      videoPlayer.current.currentTime = playFrom;
+    }
+  }, [playFrom]);
 
   useEffect(() => {
     if (videoPlayer.current) {


### PR DESCRIPTION
### Description

Changes the design of the subtitle preview to show the entire set of subtitle segments, rather than just the last three. As the media is playing, the active segment will highlight and scroll down the list. Clicking on a segment will jump the media to that timestamp.