### PR TITLE
Configure Enabled Echo Source Types

### DIFF
--- a/echo/ui/src/components/RecordEcho.tsx
+++ b/echo/ui/src/components/RecordEcho.tsx
@@ -24,7 +24,7 @@ import { useReactMediaRecorder } from "react-media-recorder";
 import { v4 as uuidv4 } from "uuid";
 
 import useCreateEcho from "hooks/useCreateEcho";
-import { EchoSourceType, SupportedMediaType } from "utils";
+import { EchoSourceType, SupportedMediaType, enabledEchoSourceTypes } from "utils";
 
 import AudioWaveform from "./AudioWaveform";
 
@@ -193,30 +193,38 @@ export default function RecordEcho({
           direction={"left"}
           hidden={recordingStatus !== "idle"}
           icon={<SpeedDialIcon sx={{ color: "#FFFFFF" }} openIcon={<GraphicEqIcon htmlColor="#FFFFFF" />} />}>
-          <SpeedDialAction
-            data-cy={"create-echo-microphone"}
-            icon={<KeyboardVoiceIcon />}
-            onClick={selectRecording}
-            tooltipTitle={"Record Audio"}
-          />
-          <SpeedDialAction
-            data-cy={"create-echo-youtube"}
-            icon={<YouTubeIcon />}
-            onClick={selectYouTubeURL}
-            tooltipTitle={"YouTube URL"}
-          />
-          <SpeedDialAction
-            data-cy={"create-echo-audio-upload"}
-            icon={<AudioFileIcon />}
-            onClick={selectSourceFile}
-            tooltipTitle={"Choose Audio File"}
-          />
-          <SpeedDialAction
-            data-cy={"create-echo-video-upload"}
-            icon={<VideoFileIcon />}
-            onClick={selectSourceFile}
-            tooltipTitle={"Choose Video File"}
-          />
+          {enabledEchoSourceTypes.get(EchoSourceType.recording) && (
+            <SpeedDialAction
+              data-cy={"create-echo-microphone"}
+              icon={<KeyboardVoiceIcon />}
+              onClick={selectRecording}
+              tooltipTitle={"Record Audio"}
+            />
+          )}
+          {enabledEchoSourceTypes.get(EchoSourceType.youtube) && (
+            <SpeedDialAction
+              data-cy={"create-echo-youtube"}
+              icon={<YouTubeIcon />}
+              onClick={selectYouTubeURL}
+              tooltipTitle={"YouTube URL"}
+            />
+          )}
+          {enabledEchoSourceTypes.get(EchoSourceType.file) && (
+            <SpeedDialAction
+              data-cy={"create-echo-audio-upload"}
+              icon={<AudioFileIcon />}
+              onClick={selectSourceFile}
+              tooltipTitle={"Choose Audio File"}
+            />
+          )}
+          {enabledEchoSourceTypes.get(EchoSourceType.file) && (
+            <SpeedDialAction
+              data-cy={"create-echo-video-upload"}
+              icon={<VideoFileIcon />}
+              onClick={selectSourceFile}
+              tooltipTitle={"Choose Video File"}
+            />
+          )}
           {/* Hidden source file input */}
           <input
             ref={sourceFileInput}

--- a/echo/ui/src/utils/index.ts
+++ b/echo/ui/src/utils/index.ts
@@ -19,6 +19,11 @@ export enum EchoSourceType {
   youtube = "youtube",
 }
 
+export const enabledEchoSourceTypes = new Map<EchoSourceType, boolean>()
+  .set(EchoSourceType.file, process.env.REACT_APP_ECHO_SOURCE_TYPE_FILE_ENABLED !== "false")
+  .set(EchoSourceType.recording, process.env.REACT_APP_ECHO_SOURCE_TYPE_RECORDING_ENABLED !== "false")
+  .set(EchoSourceType.youtube, process.env.REACT_APP_ECHO_SOURCE_TYPE_YOUTUBE_ENABLED !== "false");
+
 export const isAudio = (mediaType: SupportedMediaType) => mediaType.split("/")[0] === "audio";
 export const isVideo = (mediaType: SupportedMediaType) => mediaType.split("/")[0] === "video";
 


### PR DESCRIPTION
### Description

Adds the ability to configure which source types are enabled using build-time environment variables for the frontend.

The same environment variables are also used on the backend to guarantee that bypassing the UI using the CLI/API cannot be done.