### PR TITLE
Fix Flask Warning

### DIFF
--- a/echo/components/database/server.py
+++ b/echo/components/database/server.py
@@ -2,12 +2,12 @@ import os
 import pathlib
 from typing import List, Optional, Type
 
+import uvicorn
 from fastapi import FastAPI
 from lightning import BuildConfig, LightningWork
 from lightning_app.storage import Path
 from lightning_app.utilities.app_helpers import Logger
 from sqlmodel import Session, SQLModel, select
-from uvicorn import run
 
 from echo.models.echo import Echo
 from echo.models.general import GeneralModel
@@ -129,7 +129,7 @@ class Database(LightningWork):
         app.post("/general/")(general_post)
         app.put("/general/")(general_put)
 
-        run(app, host=self.host, port=self.port, log_level="error")
+        uvicorn.run(app, host=self.host, port=self.port, log_level="error")
 
     def alive(self):
         """Hack: Returns whether the server is alive."""

--- a/echo/components/fileserver.py
+++ b/echo/components/fileserver.py
@@ -4,6 +4,7 @@ import subprocess
 from dataclasses import dataclass
 
 import magic
+import uvicorn
 from flask import Flask, request, send_file
 from flask_cors import CORS
 from lightning import BuildConfig, LightningWork
@@ -64,7 +65,7 @@ class FileServer(LightningWork):
             """Download a file for a specific Echo."""
             return self.download_file(echo_id)
 
-        flask_app.run(host=self.host, port=self.port, load_dotenv=False)
+        uvicorn.run(app=flask_app, host=self.host, port=self.port, log_level="error")
 
     def alive(self):
         """Hack: Returns whether the server is alive."""


### PR DESCRIPTION
### Description

Use 'uvicorn.run()' to run the Flask fileserver. This removes the 'do not use this in production' warning.