### PR TITLE
Remove Flask in Favor of FastAPI for FileServer

### DIFF
--- a/echo/components/database/server.py
+++ b/echo/components/database/server.py
@@ -2,12 +2,12 @@ import os
 import pathlib
 from typing import List, Optional, Type
 
+import uvicorn
 from fastapi import FastAPI
 from lightning import BuildConfig, LightningWork
 from lightning_app.storage import Path
 from lightning_app.utilities.app_helpers import Logger
 from sqlmodel import Session, SQLModel, select
-from uvicorn import run
 
 from echo.models.echo import Echo
 from echo.models.general import GeneralModel
@@ -129,7 +129,7 @@ class Database(LightningWork):
         app.post("/general/")(general_post)
         app.put("/general/")(general_put)
 
-        run(app, host=self.host, port=self.port, log_level="error")
+        uvicorn.run(app, host=self.host, port=self.port, log_level="error")
 
     def alive(self):
         """Hack: Returns whether the server is alive."""

--- a/echo/components/fileserver.py
+++ b/echo/components/fileserver.py
@@ -4,12 +4,13 @@ import subprocess
 from dataclasses import dataclass
 
 import magic
-from flask import Flask, request, send_file
-from flask_cors import CORS
+import uvicorn
+from fastapi import FastAPI, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from lightning import BuildConfig, LightningWork
 from lightning_app.storage import Drive
 from lightning_app.utilities.app_helpers import Logger
-from werkzeug.datastructures import FileStorage
 
 from echo.media.mime import UNSUPPORTED_MEDIA_TYPES, get_mimetype
 from echo.monitoring.sentry import init_sentry
@@ -33,7 +34,7 @@ class FileServer(LightningWork):
             chunk_size: The quantity of bytes to download/upload at once.
         """
         super().__init__(
-            cloud_build_config=CustomBuildConfig(requirements=["flask", "flask-cors", "python-magic"]),
+            cloud_build_config=CustomBuildConfig(requirements=["python-magic"]),
             parallel=True,
             **kwargs,
         )
@@ -49,42 +50,47 @@ class FileServer(LightningWork):
         self.uploaded_files = dict()
 
     def run(self):
-        flask_app = Flask(__name__)
-        CORS(flask_app)
+        app = FastAPI()
 
-        @flask_app.put("/upload/<echo_id>")
-        def upload_file(echo_id: str):
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        @app.put("/upload/{echo_id}")
+        def upload_file(echo_id: str, file: UploadFile):
             """Upload a file directly as form data."""
-            file = request.files["file"]
-
             return self.upload_file(echo_id, file)
 
-        @flask_app.get("/download/<echo_id>")
+        @app.get("/download/{echo_id}")
         def download_file(echo_id: str):
             """Download a file for a specific Echo."""
             return self.download_file(echo_id)
 
-        flask_app.run(host=self.host, port=self.port, load_dotenv=False)
+        uvicorn.run(app, host=self.host, port=self.port, log_level="error")
 
     def alive(self):
         """Hack: Returns whether the server is alive."""
         return self.url != ""
 
-    def upload_file(self, echo_id: str, file: FileStorage):
+    def upload_file(self, echo_id: str, file: UploadFile):
         """Upload a file while tracking its progress."""
         self.uploaded_files[echo_id] = {"progress": (0, None), "done": False}
 
         # Save file to shared Drive
         filepath = self._get_filepath(echo_id)
         with open(filepath, "wb") as out_file:
-            content = file.read(self.chunk_size)
+            content = file.file.read(self.chunk_size)
             while content:
                 size = out_file.write(content)
                 self.uploaded_files[echo_id]["progress"] = (
                     self.uploaded_files[echo_id]["progress"][0] + size,
                     None,
                 )
-                content = file.read(self.chunk_size)
+                content = file.file.read(self.chunk_size)
 
         if get_mimetype(filepath) in UNSUPPORTED_MEDIA_TYPES:
             # TODO(alecmerdler): Figure out how to use `ffmpeg-python` rather than shelling out...
@@ -130,7 +136,7 @@ class FileServer(LightningWork):
 
         mimetype = magic.Magic(mime=True).from_file(filepath)
 
-        return send_file(filepath, mimetype=mimetype)
+        return FileResponse(path=filepath, filename=filepath, media_type=mimetype)
 
     def _get_drive_filepath(self, echo_id: str):
         """Returns file path stored on the shared Drive."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 lightning
-flask
-flask-cors
 sqlmodel
 pydantic
 uvicorn
 fastapi
+python-multipart
 humps
 pytube
 sentry-sdk


### PR DESCRIPTION
### Description

There was no need to have both Flask and FastAPI for our different Works. We were only using Flask because it was copied from the docs.