### PR TITLE
Implement REST API

### DIFF
--- a/echo/ui/openapi.json
+++ b/echo/ui/openapi.json
@@ -279,6 +279,179 @@
         }
       }
     },
+    "/api/echoes": {
+      "get": {
+        "tags": ["app_api"],
+        "summary": "Handle List Echoes",
+        "operationId": "handle_list_echoes_api_echoes_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            },
+            "name": "user_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["app_api"],
+        "summary": "Handle Create Echo",
+        "operationId": "handle_create_echo_api_echoes_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Echo"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/echoes/{echo_id}": {
+      "get": {
+        "tags": ["app_api"],
+        "summary": "Handle Get Echo",
+        "operationId": "handle_get_echo_api_echoes__echo_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Echo Id",
+              "type": "string"
+            },
+            "name": "echo_id",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "title": "Include Segments",
+              "type": "boolean"
+            },
+            "name": "include_segments",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["app_api"],
+        "summary": "Handle Delete Echo",
+        "operationId": "handle_delete_echo_api_echoes__echo_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Echo Id",
+              "type": "string"
+            },
+            "name": "echo_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/login": {
+      "get": {
+        "tags": ["app_api"],
+        "summary": "Handle Login",
+        "operationId": "handle_login_api_login_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/command/create_echo": {
       "post": {
         "tags": ["app_client_command"],
@@ -314,8 +487,8 @@
             }
           }
         },
-        "cls_name": "CreateEcho",
-        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/echo.py"
+        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/echo.py",
+        "cls_name": "CreateEcho"
       }
     },
     "/command/list_echoes": {
@@ -353,8 +526,8 @@
             }
           }
         },
-        "cls_name": "ListEchoes",
-        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/echo.py"
+        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/echo.py",
+        "cls_name": "ListEchoes"
       }
     },
     "/command/get_echo": {
@@ -392,8 +565,8 @@
             }
           }
         },
-        "cls_name": "GetEcho",
-        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/echo.py"
+        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/echo.py",
+        "cls_name": "GetEcho"
       }
     },
     "/command/delete_echo": {
@@ -431,8 +604,8 @@
             }
           }
         },
-        "cls_name": "DeleteEcho",
-        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/echo.py"
+        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/echo.py",
+        "cls_name": "DeleteEcho"
       }
     },
     "/command/login": {
@@ -450,8 +623,8 @@
             }
           }
         },
-        "cls_name": "Login",
-        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/auth.py"
+        "cls_path": "/home/alec/work/Lightning-AI/LAI-Echo-App/echo/commands/auth.py",
+        "cls_name": "Login"
       }
     },
     "/api{full_path}": {

--- a/echo/ui/src/generated/EchoClient.ts
+++ b/echo/ui/src/generated/EchoClient.ts
@@ -6,12 +6,14 @@
 import type { BaseHttpRequest } from "./core/BaseHttpRequest";
 import { FetchHttpRequest } from "./core/FetchHttpRequest";
 import type { OpenAPIConfig } from "./core/OpenAPI";
+import { AppApiService } from "./services/AppApiService";
 import { AppClientCommandService } from "./services/AppClientCommandService";
 import { DefaultService } from "./services/DefaultService";
 
 type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
 
 export class EchoClient {
+  public readonly appApi: AppApiService;
   public readonly appClientCommand: AppClientCommandService;
   public readonly default: DefaultService;
 
@@ -30,6 +32,7 @@ export class EchoClient {
       ENCODE_PATH: config?.ENCODE_PATH,
     });
 
+    this.appApi = new AppApiService(this.request);
     this.appClientCommand = new AppClientCommandService(this.request);
     this.default = new DefaultService(this.request);
   }

--- a/echo/ui/src/generated/index.ts
+++ b/echo/ui/src/generated/index.ts
@@ -17,5 +17,6 @@ export type { HTTPValidationError } from "./models/HTTPValidationError";
 export type { ListEchoesConfig } from "./models/ListEchoesConfig";
 export type { ValidationError } from "./models/ValidationError";
 
+export { AppApiService } from "./services/AppApiService";
 export { AppClientCommandService } from "./services/AppClientCommandService";
 export { DefaultService } from "./services/DefaultService";

--- a/echo/ui/src/generated/services/AppApiService.ts
+++ b/echo/ui/src/generated/services/AppApiService.ts
@@ -1,0 +1,103 @@
+/* istanbul ignore file */
+
+/* tslint:disable */
+
+/* eslint-disable */
+import type { BaseHttpRequest } from "../core/BaseHttpRequest";
+import type { CancelablePromise } from "../core/CancelablePromise";
+import type { Echo } from "../models/Echo";
+
+export class AppApiService {
+  constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+  /**
+   * Handle List Echoes
+   * @param userId
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public handleListEchoesApiEchoesGet(userId: string): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/api/echoes",
+      query: {
+        user_id: userId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+
+  /**
+   * Handle Create Echo
+   * @param requestBody
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public handleCreateEchoApiEchoesPost(requestBody: Echo): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: "POST",
+      url: "/api/echoes",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+
+  /**
+   * Handle Get Echo
+   * @param echoId
+   * @param includeSegments
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public handleGetEchoApiEchoesEchoIdGet(echoId: string, includeSegments: boolean): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/api/echoes/{echo_id}",
+      path: {
+        echo_id: echoId,
+      },
+      query: {
+        include_segments: includeSegments,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+
+  /**
+   * Handle Delete Echo
+   * @param echoId
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public handleDeleteEchoApiEchoesEchoIdDelete(echoId: string): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: "DELETE",
+      url: "/api/echoes/{echo_id}",
+      path: {
+        echo_id: echoId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+
+  /**
+   * Handle Login
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public handleLoginApiLoginGet(): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/api/login",
+    });
+  }
+}

--- a/echo/ui/src/hooks/useCreateEcho.ts
+++ b/echo/ui/src/hooks/useCreateEcho.ts
@@ -32,7 +32,7 @@ export default function useCreateEcho() {
         await fetch(uploadURL, { body, method: "PUT" });
       }
 
-      return echoClient.appClientCommand.createEchoCommandCreateEchoPost({
+      return echoClient.appApi.handleCreateEchoApiEchoesPost({
         id: echoID,
         userId,
         displayName,

--- a/echo/ui/src/hooks/useDeleteEcho.ts
+++ b/echo/ui/src/hooks/useDeleteEcho.ts
@@ -1,19 +1,13 @@
 import { useMutation, useQueryClient } from "react-query";
 import { echoClient } from "services/echoClient";
 
-import useAuth from "./useAuth";
-
 export default function useDeleteEcho() {
   const queryClient = useQueryClient();
-  const { userId } = useAuth();
 
-  return useMutation(
-    (echoID: string) => echoClient.appClientCommand.deleteEchoCommandDeleteEchoPost({ userId, echoId: echoID }),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries("listEchoes");
-        queryClient.invalidateQueries(["getEcho"]);
-      },
+  return useMutation((echoID: string) => echoClient.appApi.handleDeleteEchoApiEchoesEchoIdDelete(echoID), {
+    onSuccess: () => {
+      queryClient.invalidateQueries("listEchoes");
+      queryClient.invalidateQueries(["getEcho"]);
     },
-  );
+  });
 }

--- a/echo/ui/src/hooks/useGetEcho.ts
+++ b/echo/ui/src/hooks/useGetEcho.ts
@@ -4,19 +4,15 @@ import { echoClient } from "services/echoClient";
 import { Echo } from "generated";
 import { Segment } from "types/echo";
 
-import useAuth from "./useAuth";
-
 type GetEchoResponse = {
   echo: Echo;
   segments: Segment[];
 };
 
 export default function useGetEcho(echoId?: string, includeSegments?: boolean) {
-  const { userId } = useAuth();
-
   return useQuery<GetEchoResponse>(
     ["getEcho", echoId, includeSegments],
-    () => echoClient.appClientCommand.getEchoCommandGetEchoPost({ userId, echoId: echoId!, includeSegments }),
+    () => echoClient.appApi.handleGetEchoApiEchoesEchoIdGet(echoId!, includeSegments ?? false),
     { enabled: !!echoId && !!includeSegments },
   );
 }

--- a/echo/ui/src/hooks/useListEchoes.tsx
+++ b/echo/ui/src/hooks/useListEchoes.tsx
@@ -9,15 +9,11 @@ export default function useListEchoes() {
   const queryClient = useQueryClient();
   const { userId } = useAuth();
 
-  return useQuery<Echo[]>(
-    "listEchoes",
-    () => echoClient.appClientCommand.listEchoesCommandListEchoesPost({ userId }),
-    {
-      enabled: !!userId,
-      refetchInterval: 1000,
-      onSuccess: () => {
-        queryClient.invalidateQueries(["getEcho"]);
-      },
+  return useQuery<Echo[]>("listEchoes", () => echoClient.appApi.handleListEchoesApiEchoesGet(userId!), {
+    enabled: !!userId,
+    refetchInterval: 1000,
+    onSuccess: () => {
+      queryClient.invalidateQueries(["getEcho"]);
     },
-  );
+  });
 }

--- a/echo/ui/src/routes/dashboard/components/EchoesList.tsx
+++ b/echo/ui/src/routes/dashboard/components/EchoesList.tsx
@@ -80,7 +80,10 @@ export default function EchoesList({ onSelectEchoID, onToggleCreatingEcho, selec
         <Typography variant={"body2"}>{echo.createdAt}</Typography>,
         <Typography variant={"body2"}>{echo.completedTranscriptionAt ?? "-"}</Typography>,
         <Stack direction={"row"}>
-          <IconButton aria-label="Delete" disabled={!echo.text} onClick={() => deleteEchoMutation.mutate(echo.id)}>
+          <IconButton
+            aria-label="Delete"
+            disabled={!echo.completedTranscriptionAt}
+            onClick={() => deleteEchoMutation.mutate(echo.id)}>
             <DeleteIcon fontSize={"small"} />
           </IconButton>
         </Stack>,

--- a/echo/ui/src/routes/mobile-demo/components/EchoesListMobile.tsx
+++ b/echo/ui/src/routes/mobile-demo/components/EchoesListMobile.tsx
@@ -66,7 +66,7 @@ export default function EchoesListMobile({ onSelectEchoID }: Props) {
               edge="end"
               aria-label="delete"
               onClick={e => deleteEcho(e, echo.id)}
-              disabled={!echo.text || deleteEchoMutation.variables === echo.id}>
+              disabled={!echo.completedTranscriptionAt || deleteEchoMutation.variables === echo.id}>
               <DeleteIcon />
             </IconButton>
           }>


### PR DESCRIPTION
### Description

Previously, we were relying on the basic HTTP API created as a result of using 'configure_commands()', which worked. But it is easy to use 'configure_api()' to define proper REST API routes and just call the existing methods we were using before. The advantage of using 'configure_api()' is that we can return proper HTTP error codes (like HTTP 404).

Resolves #40 