### PR TITLE
Stop Polling 'ListEchoes()' API to Fix Recording Bug

### DIFF
--- a/echo/ui/src/hooks/useListEchoes.tsx
+++ b/echo/ui/src/hooks/useListEchoes.tsx
@@ -11,7 +11,6 @@ export default function useListEchoes() {
 
   return useQuery<Echo[]>("listEchoes", () => echoClient.appApi.handleListEchoesApiEchoesGet(userId!), {
     enabled: !!userId,
-    refetchInterval: 1000,
     onSuccess: () => {
       queryClient.invalidateQueries(["getEcho"]);
     },


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Removes the 'refetchInterval: 1000' from the 'ListEchoes()' query. This was causing a re-render of the '<RecordEcho>' component every second, which caused it to crash after only 15 seconds of recording.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
