### PR TITLE
Enable Polling When Not Recording

### DIFF
--- a/echo/ui/src/App.tsx
+++ b/echo/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import { LightningStateContextProvider } from "hooks/useLightningState";
+import { RecordEchoContextProvider } from "hooks/useRecordEcho";
 import { theme } from "lightning-ui/src/design-system/theme";
 import Dashboard from "routes/dashboard/Dasboard";
 import MobileDemo from "routes/mobile-demo/MobileDemo";
@@ -65,12 +66,14 @@ function App() {
       <CssBaseline />
       <QueryClientProvider client={queryClient}>
         <LightningStateContextProvider>
-          <BrowserRouter>
-            <Routes>
-              {/* NOTE: Framework does not support client-side routing yet, app is served under `/view/home` */}
-              <Route path={"*"} element={onMobile ? <MobileDemo /> : <Dashboard />} />
-            </Routes>
-          </BrowserRouter>
+          <RecordEchoContextProvider>
+            <BrowserRouter>
+              <Routes>
+                {/* NOTE: Framework does not support client-side routing yet, app is served under `/view/home` */}
+                <Route path={"*"} element={onMobile ? <MobileDemo /> : <Dashboard />} />
+              </Routes>
+            </BrowserRouter>
+          </RecordEchoContextProvider>
         </LightningStateContextProvider>
       </QueryClientProvider>
     </MuiThemeProvider>

--- a/echo/ui/src/components/RecordEcho.tsx
+++ b/echo/ui/src/components/RecordEcho.tsx
@@ -26,6 +26,7 @@ import { useReactMediaRecorder } from "react-media-recorder";
 import { v4 as uuidv4 } from "uuid";
 
 import useCreateEcho from "hooks/useCreateEcho";
+import { useRecordEcho } from "hooks/useRecordEcho";
 import useValidateEcho from "hooks/useValidateEcho";
 import { EchoSourceType, SupportedMediaType, enabledEchoSourceTypes, recordingMaxDurationSeconds } from "utils";
 import { secondsToTime } from "utils/time";
@@ -63,6 +64,7 @@ export default function RecordEcho({
 
   const createEchoMutation = useCreateEcho();
   const validateEchoMutation = useValidateEcho();
+  const { setIsRecording } = useRecordEcho();
 
   const {
     status: recordingStatus,
@@ -78,6 +80,8 @@ export default function RecordEcho({
       mimeType: SupportedMediaType.audioWAV,
     },
     onStart: () => {
+      setIsRecording(true);
+
       const interval = setInterval(() => {
         if (recordingTimeElapsed.current >= recordingMaxDurationSeconds) {
           stopRecording();
@@ -88,6 +92,7 @@ export default function RecordEcho({
       }, 1000);
     },
     onStop: (blobUrl, blob) => {
+      setIsRecording(false);
       setSourceBlob(blob);
       setSourceBlobURL(blobUrl);
       recordingTimeElapsed.current = 0;

--- a/echo/ui/src/hooks/useListEchoes.tsx
+++ b/echo/ui/src/hooks/useListEchoes.tsx
@@ -4,13 +4,19 @@ import { echoClient } from "services/echoClient";
 import { Echo } from "generated";
 
 import useAuth from "./useAuth";
+import { useRecordEcho } from "./useRecordEcho";
+
+const refetchInterval = 1000;
 
 export default function useListEchoes() {
   const queryClient = useQueryClient();
   const { userId } = useAuth();
+  const { isRecording } = useRecordEcho();
 
   return useQuery<Echo[]>("listEchoes", () => echoClient.appApi.handleListEchoesApiEchoesGet(userId!), {
     enabled: !!userId,
+    refetchInterval: echoes =>
+      !isRecording && (echoes?.some(echo => !echo.completedTranscriptionAt) ? refetchInterval : false),
     onSuccess: () => {
       queryClient.invalidateQueries(["getEcho"]);
     },

--- a/echo/ui/src/hooks/useRecordEcho.tsx
+++ b/echo/ui/src/hooks/useRecordEcho.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, useState } from "react";
+
+type RecordEchoContextType = {
+  isRecording: boolean;
+  setIsRecording: (isRecording: boolean) => void;
+};
+
+const RecordEchoContext = createContext<RecordEchoContextType>({ isRecording: false, setIsRecording: () => {} });
+
+// TODO: Move `useReactMediaRecorder()` hook call here so that only one recorder instance is created...
+export function RecordEchoContextProvider(props: React.PropsWithChildren<{}>) {
+  const [isRecording, setIsRecording] = useState(false);
+
+  return (
+    <RecordEchoContext.Provider value={{ isRecording, setIsRecording }}>{props.children}</RecordEchoContext.Provider>
+  );
+}
+
+export const useRecordEcho = () => useContext(RecordEchoContext);

--- a/echo/ui/src/routes/dashboard/components/CreateEchoForm.tsx
+++ b/echo/ui/src/routes/dashboard/components/CreateEchoForm.tsx
@@ -1,9 +1,12 @@
-import { useCallback, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Stack } from "@mui/material";
 
 import { TextField } from "lightning-ui/src/design-system/components";
 import { EchoSourceType, videoMaxDurationSeconds } from "utils";
+
+const displayNamePlaceholder = "Five Easy Tricks to Learning ML";
+const youtubeVideoPlaceholder = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
 
 type Props = {
   sourceType: EchoSourceType;
@@ -12,43 +15,55 @@ type Props = {
 };
 
 export default function CreateEchoForm({ sourceType, youtubeURLUpdated, displayNameUpdated }: Props) {
-  const [displayName, setDisplayName] = useState("");
-  const [sourceYouTubeURL, setSourceYouTubeURL] = useState("");
+  const [displayName, setDisplayName] = useState(displayNamePlaceholder);
+  const [sourceYouTubeURL, setSourceYouTubeURL] = useState(youtubeVideoPlaceholder);
 
-  const onDisplayNameUpdated = useCallback(
-    (displayName: string) => {
-      setDisplayName(displayName);
-      displayNameUpdated(displayName);
-    },
-    [displayNameUpdated],
-  );
+  const displayNameInput = useRef<HTMLInputElement>(null);
+  const youtubeURLInput = useRef<HTMLInputElement>(null);
 
-  const onChangeYouTubeURL = useCallback(
-    (url: string) => {
-      setSourceYouTubeURL(url);
-      youtubeURLUpdated(url);
-    },
-    [youtubeURLUpdated],
-  );
+  useEffect(() => {
+    // Clear placeholders on input click
+    if (displayNameInput.current) {
+      displayNameInput.current.addEventListener("click", () => {
+        setDisplayName(currentValue => (currentValue === displayNamePlaceholder ? "" : currentValue));
+      });
+    }
+
+    if (youtubeURLInput.current) {
+      youtubeURLInput.current.addEventListener("click", () => {
+        setSourceYouTubeURL(currentValue => (currentValue === youtubeVideoPlaceholder ? "" : currentValue));
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    displayNameUpdated(displayName);
+  }, [displayName, displayNameUpdated]);
+
+  useEffect(() => {
+    youtubeURLUpdated(sourceYouTubeURL);
+  }, [sourceYouTubeURL, youtubeURLUpdated]);
 
   return (
     <Stack direction={"column"} spacing={4} maxWidth={"75vh"}>
       <TextField
         label={"Name"}
         data-cy={"create-echo-name"}
-        placeholder={"My Echo"}
-        helperText={'Give your Echo a name based on the content (e.g. "Commencement Speech 2014")'}
+        placeholder={displayNamePlaceholder}
+        helperText={"Give your Echo a name based on the content."}
         value={displayName}
-        onChange={value => onDisplayNameUpdated(value ?? "")}
+        onChange={value => setDisplayName(value ?? "")}
+        ref={displayNameInput}
         optional={false}
       />
       {sourceType === EchoSourceType.youtube && (
         <TextField
           label={"YouTube URL"}
-          placeholder={"https://www.youtube.com/watch?v=dQw4w9WgXcQ"}
+          placeholder={youtubeVideoPlaceholder}
           data-cy={"create-echo-youtube-url"}
           value={sourceYouTubeURL}
-          onChange={value => onChangeYouTubeURL(value ?? "")}
+          onChange={value => setSourceYouTubeURL(value ?? "")}
+          ref={youtubeURLInput}
           helperText={
             videoMaxDurationSeconds
               ? `Video must be less than ${(videoMaxDurationSeconds / 60).toFixed(0)} minutes long.`

--- a/echo/ui/src/routes/dashboard/components/EchoesList.tsx
+++ b/echo/ui/src/routes/dashboard/components/EchoesList.tsx
@@ -64,6 +64,14 @@ export default function EchoesList({ onSelectEchoID, onToggleCreatingEcho, selec
     [onSelectEchoID, onToggleCreatingEcho],
   );
 
+  const onDeleteEcho = useCallback(
+    (echoID: string) => {
+      onSelectEchoID();
+      deleteEchoMutation.mutate(echoID);
+    },
+    [deleteEchoMutation, onSelectEchoID],
+  );
+
   const rows = useMemo(
     () =>
       (echoes ?? []).map(echo => [
@@ -77,18 +85,20 @@ export default function EchoesList({ onSelectEchoID, onToggleCreatingEcho, selec
         />,
         <Typography variant={"body2"}>{echo.displayName ?? echo.id}</Typography>,
         <Typography variant={"body2"}>{echo.mediaType}</Typography>,
-        <Typography variant={"body2"}>{echo.createdAt}</Typography>,
-        <Typography variant={"body2"}>{echo.completedTranscriptionAt ?? "-"}</Typography>,
+        <Typography variant={"body2"}>{echo.createdAt ? new Date(echo.createdAt).toLocaleString() : "-"}</Typography>,
+        <Typography variant={"body2"}>
+          {echo.completedTranscriptionAt ? new Date(echo.completedTranscriptionAt).toLocaleString() : "-"}
+        </Typography>,
         <Stack direction={"row"}>
           <IconButton
             aria-label="Delete"
             disabled={!echo.completedTranscriptionAt}
-            onClick={() => deleteEchoMutation.mutate(echo.id)}>
+            onClick={() => onDeleteEcho(echo.id)}>
             <DeleteIcon fontSize={"small"} />
           </IconButton>
         </Stack>,
       ]),
-    [echoes, selectEcho, selectedEchoID, deleteEchoMutation],
+    [echoes, selectEcho, selectedEchoID, onDeleteEcho],
   );
 
   if (isLoading) {
@@ -112,11 +122,7 @@ export default function EchoesList({ onSelectEchoID, onToggleCreatingEcho, selec
 
   return (
     <Stack direction={"column"} justifyContent={"space-between"} height={"100%"}>
-      <Stack direction={"row"} marginBottom={2}>
-        <Typography variant={"h6"}>
-          {createEchoWithSourceType !== undefined ? "Create Echo" : "Your Echoes"}
-        </Typography>
-      </Stack>
+      <Typography variant={"h6"}>{createEchoWithSourceType !== undefined ? "Create Echo" : "Your Echoes"}</Typography>
       <Box height={"75%"} sx={{ overflowY: "scroll" }}>
         {createEchoWithSourceType !== undefined ? (
           <CreateEchoForm

--- a/echo/ui/src/routes/mobile-demo/MobileDemo.tsx
+++ b/echo/ui/src/routes/mobile-demo/MobileDemo.tsx
@@ -42,9 +42,7 @@ export default function MobileDemo() {
           <EchoDetail echoID={selectedEchoID} goBack={() => setSelectedEchoID(undefined)} />
         ) : (
           <>
-            <Typography variant={"h6"} marginX={2} marginTop={2}>
-              Your Echoes
-            </Typography>
+            <Typography variant={"h6"}>Your Echoes</Typography>
             <Stack height={"75%"} sx={{ overflowY: "scroll" }}>
               <EchoesListMobile onSelectEchoID={setSelectedEchoID} />
             </Stack>

--- a/echo/ui/src/routes/mobile-demo/components/EchoesListMobile.tsx
+++ b/echo/ui/src/routes/mobile-demo/components/EchoesListMobile.tsx
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import DeleteIcon from "@mui/icons-material/Delete";
 import GraphicEqIcon from "@mui/icons-material/GraphicEq";
-import PendingIcon from "@mui/icons-material/Pending";
 import {
   CircularProgress,
   IconButton,
@@ -69,8 +68,22 @@ export default function EchoesListMobile({ onSelectEchoID }: Props) {
               <DeleteIcon />
             </IconButton>
           }>
-          <ListItemIcon>{!echo.text ? <PendingIcon /> : <CheckCircleIcon color={"primary"} />}</ListItemIcon>
-          <ListItemText primary={echo.displayName} secondary={echo.mediaType} />
+          <ListItemIcon>
+            {!echo.text ? <CircularProgress size={"1em"} /> : <CheckCircleIcon color={"primary"} />}
+          </ListItemIcon>
+          <ListItemText
+            primary={echo.displayName}
+            secondary={
+              <Stack direction={"column"}>
+                <Typography variant="body2" color="text.primary">
+                  {echo.mediaType}
+                </Typography>
+                {echo.completedTranscriptionAt
+                  ? `Completed ${new Date(echo.completedTranscriptionAt).toLocaleString()}`
+                  : " Processing..."}
+              </Stack>
+            }
+          />
         </ListItem>
       ))}
     </List>


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

We previously removed polling to reduce load on the API server
and fix a bug during recording caused by too many re-renders.
However, without polling the list of Echoes will not update
when an Echo completes processing, giving the impression that
the app is slower than it actually is. This adds back polling
but disables it if the microphone is recording using a new
<RecordEchoContextProvider> and associated hooks.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
