### PR TITLE
Add 'PUBLIC_URL' to Build to Use CDN in Production

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,6 +64,7 @@ jobs:
       - name: Build frontend
         run: cd echo/ui && yarn build
         env:
+          PUBLIC_URL: https://storage.googleapis.com/lightning-echo-prod/build
           REACT_APP_ECHO_ROOT_PATH: ${{ inputs.rootPath }}
           REACT_APP_ECHO_SHOW_BANNER: "true"
           REACT_APP_ECHO_SOURCE_TYPE_FILE_ENABLED: "${{ inputs.sourceTypeFileEnabled }}"


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Without the 'PUBLIC_URL' environment variable, Webpack won't build the frontend to use the CDN assets.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
