### PR TITLE
Leave Minimum Replicas When Killing Idle Works

### DIFF
--- a/echo/components/loadbalancing/loadbalancer.py
+++ b/echo/components/loadbalancing/loadbalancer.py
@@ -81,10 +81,10 @@ class LoadBalancer(LightningFlow):
                 new_work.run(**self._dummy_run_kwargs)
 
             # Check for idle Works and stop them to save on cloud costs
-            if len(self._work_pool.items()) <= min_replicas:
-                return
-
             for work_name, work in self._work_pool.copy().items():
+                if len(self._work_pool.items()) <= min_replicas:
+                    return
+
                 if self._is_idle(work):
                     logger.info(f"Found idle Work ({work.name}), stopping it")
                     self._remove_work(work_name)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Fixes a bug where calling the 'ensure_min_replicas()' method on the 'LoadBalancer' component would scale down all idle Works without leaving the minimum number running.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
