### PR TITLE
Revert "Bump python-multipart from 0.0.5 to 0.0.6"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ sqlmodel==0.0.8
 pydantic==1.10.4
 uvicorn==0.18.3
 fastapi==0.85.0
-python-multipart==0.0.6
+python-multipart==0.0.5
 humps==0.2.2
 pytube==12.1.2
 sentry-sdk==1.9.10


### PR DESCRIPTION
Somehow this causes `pip install` to fail.